### PR TITLE
Booting API server in advance & UI bug fix

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+        <link rel="stylesheet" href="/index.css" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SeqImprove</title>
 </head>
 

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -5,10 +5,11 @@ import CurationForm from './components/CurationForm'
 import UploadForm from './components/UploadForm'
 import { MantineProvider, Center, Box, Text, Space } from '@mantine/core'
 import { getSearchParams } from './modules/util'
-
+import { bootAPIserver } from "./modules/api"
 
 export default function App() {
 
+    bootAPIserver();
     const loadSBOL = useStore(s => s.loadSBOL)
     const documentLoaded = useStore(s => !!s.document)
 

--- a/apps/web/src/components/SequenceSection.jsx
+++ b/apps/web/src/components/SequenceSection.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, forwardRef } from "react"
 import { useForceUpdate } from "@mantine/hooks"
-import { Button, Center, Group, Loader, NavLink, Space, CopyButton, ActionIcon, Tooltip, Textarea, MultiSelect } from "@mantine/core"
+import { Button, Center, Group, Loader, NavLink, Space, CopyButton, ActionIcon, Tooltip, Textarea, MultiSelect, Text } from "@mantine/core"
 import { FiDownloadCloud } from "react-icons/fi"
 import { FaCheck, FaPencilAlt, FaPlus, FaTimes, FaArrowRight } from "react-icons/fa"
 import { mutateDocument, mutateSequencePartLibrariesSelected, useAsyncLoader, useStore } from "../modules/store"
@@ -132,6 +132,41 @@ function Sequence({ colors }) {
     )
 }
 
+function MyAnnotationCheckbox({ title, color, active, onChange, featureLibrary }) {
+    const [isVisible, setIsVisible] = useState(false);
+    
+    return <div className="my-anno-checkbox-container"
+                onMouseEnter={() => setIsVisible(true)}
+                onMouseLeave={() => setIsVisible(false)}                
+           >
+               <input type="checkbox"
+                      id={title}
+                      name={title}
+                      className="my-checkbox"
+                      style={{accentColor: color}}
+                      checked={active ? "checked" : ""}
+                      onChange={onChange}
+               />
+               <label for={title} style={{color: color}}>
+                   {title}
+               </label>
+               {(!isVisible) &&
+                <span class="material-symbols-outlined">
+                    info
+                </span>
+               }
+               {isVisible && <div className="tooltip">{featureLibrary}</div>}
+           </div>
+}
+
+function MyToolTip({ featureLibrary }) {    
+    return <span className="tooltip"
+                 data-text={featureLibrary}
+           >
+               info
+           </span>    
+}
+
 function Annotations({ colors }) {
 
     const annotations = useStore(s => s.sequenceAnnotations)
@@ -155,8 +190,6 @@ function Annotations({ colors }) {
     ];
 
     const [sequencePartLibrariesSelected, setSequencePartLibrariesSelected] = useState(sequencePartLibraries);
-    // const sequencePartLibrariesSelected = useStore(s => s.sequencePartLibrariesSelected);
-    // const setSequencePartLibrariesSelected = useStore(s => s.setSequencePartLibrariesSelectedFrom(sequencePartLibraries));
 
     const AnnotationCheckboxContainer = forwardRef((props, ref) => (
         <div ref={ref} {...props}>
@@ -168,22 +201,20 @@ function Annotations({ colors }) {
         <FormSection title="Sequence Annotations" key="Sequence Annotations">
             {annotations.map((anno, i) =>
                 <Group spacing="xs" sx={{ flexGrow: 1, }} key={anno.name + '_' + i}>
-                    {anno.featureLibrary ? <Tooltip label={anno.featureLibrary.replace(/_/g, ' ').slice(0, anno.featureLibrary.length - 4)}>
-                                <AnnotationCheckboxContainer
-                                    title={anno.name}
-                                    color={colors[i]}
-                                    active={isActive(anno.id) ? 1 : 0}
-                                    onChange={val => setActive(anno.id, val)}
-                                />    
-                            </Tooltip> :
-                     <AnnotationCheckbox
-                         title={anno.name}
-                         color={colors[i]}
-                         active={isActive(anno.id) ? 1 : 0}
-                         onChange={val => setActive(anno.id, val)}
-                     />
-                    }
-                    <Copier anno={anno} sequence={sequence} />   
+                    <AnnotationCheckbox
+                        title={anno.name}
+                        color={colors[i]}
+                        active={isActive(anno.id) ? 1 : 0}
+                        onChange={val => setActive(anno.id, val)}                        
+                    />
+
+                    {anno.featureLibrary &&
+                     <MyToolTip
+                         featureLibrary={anno.featureLibrary.replace(/_/g, ' ').slice(0, anno.featureLibrary.length - 4)}
+                     >
+                     </MyToolTip>}
+                    
+                <Copier anno={anno} sequence={sequence} />   
                 </Group>              
             )}
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2,3 +2,37 @@
 body {
     min-height: 95vh;
 }
+
+.material-symbols-outlined {
+    font-size: 15px;
+    color: #a1a1a1;
+    posiiton: relative;
+}
+
+.tooltip {
+    font-size: 15px;
+    color: #a1a1a1;
+    posiiton: relative;
+    border-bottom:1px dashed #000;
+}
+
+.tooltip:before {
+    font-size: 12px;
+    content: attr(data-text);
+    position: absolute;
+    padding-left: 4px;
+    padding-right: 4px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    border-radius:10px;
+    background: #000;
+    color: #fff;
+    text-align:center;
+    text-wrap: balance;
+    z-index: 10;
+    display: none;
+}
+
+.tooltip:hover:before {
+    display: block;
+}

--- a/apps/web/src/modules/api.js
+++ b/apps/web/src/modules/api.js
@@ -1,6 +1,19 @@
 import { showServerErrorNotification } from "./util"
 import { Graph, SBOL2GraphView } from "sbolgraph"
 
+export async function bootAPIserver() {
+    try {
+        var response = await fetch(`${import.meta.env.VITE_API_LOCATION}/api/boot`);        
+    } catch (err) {
+        console.error(err);
+        return
+    }
+
+    if (response.status == 200) {
+        console.log(response);
+    }
+}
+
 export async function fetchSBOL(url) {
     try {
         return await (await fetch(url)).text()
@@ -46,8 +59,11 @@ export async function fetchAnnotateSequence({ sbolContent, selectedLibraryFileNa
         showServerErrorNotification();
         return;
     }
-    
-    console.log("Successfully annotated.");    
+
+    if (response.status == 200) {
+        console.log("Successfully annotated.");
+    }
+
     const annoLibsAssoc = result.annotations;
     
     // create and load original doc


### PR DESCRIPTION
In the previous commit, I wrote some code that would tell the server to basically load in some data, the feature library data, into computer memory after the first request to the server, so it can just use it for every request afterward. This is good, because loading that data takes a lot of time. But, what I realized when deploying the code is that Azure doesn't just keep our server running all the time. Without any requests being made to the server, it gets shut off. This means that it has to be rebooted, and that initialization process has to start all over again. This nullifies the time savings of the previous update because there aren't enough people using SeqImprove to keep the server running. So, my solution is to create an API endpoint whose only purpose is to boot up the server and trigger the setup function to load our feature library data, if and only if the server is just starting up. Then I make the front end request this API endpoint any time SeqImrpove is visited. This gets the process of loading in the part libraries started before the user even begins to upload an SBOL file, let alone try to analyze the DNA.

I also fixed a little UI bug that my last commit unfortunately created. The tooltip for displaying the part library somehow prevented the checkbox for sequence annotations from being unclicked.