### PR TITLE
Grounding bug fixed by disallowing edits on text annotations.

### DIFF
--- a/apps/web/public/Test_Part.xml
+++ b/apps/web/public/Test_Part.xml
@@ -15,7 +15,7 @@
     <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987" />
     <sbol:role rdf:resource="http://identifiers.org/so/SO:0000804" />
     <sbol:sequence rdf:resource="https://example.com/Test_Part_seq/1" />
-    <ns2:richDescription>This part makes [GFP](https://identifiers.org/NCBIGene:8790). It was tested in [E. coli](https://identifiers.org/NCBITaxon:562) and is thought to work in [B. subtilis](https://identifiers.org/NCBITaxon:518697). The circuit functions better when background levels of [lactose](https://identifiers.org/mesh:D007785) are low. [E. coli](https://identifiers.org/NCBITaxon:562) is the same as [Escherichia coli](https://identifiers.org/NCBITaxon:562). Escichia coi.</ns2:richDescription>
+    <ns2:richDescription>This part makes [GFP](https://bioregistry.io/NCBIGene:8790). It was tested in [E. coli](https://bioregistry.io/NCBITaxon:562) and is thought to work in [B. subtilis](https://bioregistry.io/NCBITaxon:518697). The circuit functions better when background levels of [lactose](https://bioregistry.io/mesh:D007785) are low. [E. coli](https://bioregistry.io/NCBITaxon:562) is the same as [Escherichia coli](https://bioregistry.io/NCBITaxon:562). Escichia coi.</ns2:richDescription>
     <ns2:targetOrganism rdf:resource="https://www.uniprot.org/taxonomy/562" />
     <ns2:protein rdf:resource="https://identifiers.org/UniProt:P42212" />
   </sbol:ComponentDefinition>

--- a/apps/web/src/components/CurationForm.jsx
+++ b/apps/web/src/components/CurationForm.jsx
@@ -226,10 +226,9 @@ function SynBioHubClientUpload({ setIsInteractingWithSynBioHub }) {
                          value={citations.join(',')}
                          description="Comma separated pubmed IDs of citations to store with the submission"
                          onChange={(e) => {
-                             const cits = e.currentTarget.value.split(',');                         
+                             const cits = e.currentTarget.value.split(',');
                              setCitations(cits.slice(0, cits.length-1).map(cit => cit.trim()).concat(cits.slice(-1)))
-                         }}
-                         withAsterisk
+                         }}                         
                          error={inputError != false}
                      />
                      <Button onClick={async () => {

--- a/apps/web/src/components/TextAnnotationCheckbox.jsx
+++ b/apps/web/src/components/TextAnnotationCheckbox.jsx
@@ -37,21 +37,23 @@ export default function TextAnnotationCheckbox({ id, color }) {
                         </Box>
                     </Tooltip>
                     <Group spacing={5}>
-                        <ActionIcon
-                            size="sm"
-                            onClick={() => openContextModal({
-                                modal: "addAndEdit",
-                                title: "Edit Annotation",
-                                innerProps: {
-                                    editing: true,
-                                    label: annotation.label,
-                                    identifier: annotation.displayId,
-                                    uri: annotation.id,
-                                }
-                            })}
-                        >
-                            <FaPencilAlt fontSize={"0.8em"} />
-                        </ActionIcon>
+                        {/*
+                           <ActionIcon
+                           size="sm"
+                           onClick={() => openContextModal({
+                           modal: "addAndEdit",
+                           title: "Edit Annotation",
+                           innerProps: {
+                           editing: true,
+                           label: annotation.label,
+                           identifier: annotation.displayId,
+                           uri: annotation.id,
+                           }
+                           })}
+                           >
+                           <FaPencilAlt fontSize={"0.8em"} />
+                           </ActionIcon>
+                          */}                        
 
                         <ActionIcon
                             size="sm"


### PR DESCRIPTION
Closes #8 

If the user needs to edit an annotation, they can just create a new annotation and delete the old one. No need to edit existing annotations.