### PR TITLE
Clean download new

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -379,8 +379,9 @@ def annotate_sequence():
     request_data = request.get_json()
     sbol_content = request_data['completeSbolContent']
     part_library_file_names = request_data['partLibraries'] 
+    clean_uris = request_data['cleanURIs']
 
-    sbol_content = run_synbio2easy(sbol_content)
+    if clean_uris: sbol_content = run_synbio2easy(sbol_content)
 
     print("Running SYNBICT...")
     # Run SYNBICT

--- a/apps/web/src/components/CurationForm.jsx
+++ b/apps/web/src/components/CurationForm.jsx
@@ -231,6 +231,7 @@ function SynBioHubClientUpload({ setIsInteractingWithSynBioHub }) {
                          }}                         
                          error={inputError != false}
                      />
+                     <Checkbox checked={overwrite} label="Overwrite?" description="Overwrite if submission exists" onChange={(event) => setOverwrite(event.currentTarget.checked)} />
                      <Button onClick={async () => {
                                  if (inputErrorID || inputErrorVersion) {
                                      showErrorNotification("Invalid Input", "Please address the issue and then submit.");

--- a/apps/web/src/components/SequenceSection.jsx
+++ b/apps/web/src/components/SequenceSection.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, forwardRef, createElement } from "react"
 import { useForceUpdate } from "@mantine/hooks"
+import { Checkbox } from '@mantine/core';
 import { Button, Center, Group, Loader, NavLink, Space, CopyButton, ActionIcon, Tooltip, Textarea, MultiSelect, Text, Highlight} from "@mantine/core"
 import { FiDownloadCloud } from "react-icons/fi"
 import { FaCheck, FaPencilAlt, FaPlus, FaTimes, FaArrowRight } from "react-icons/fa"
@@ -262,6 +263,9 @@ function Annotations({ colors }) {
     ];
 
     const [sequencePartLibrariesSelected, setSequencePartLibrariesSelected] = useState([]);
+    const isChecked = useStore((state) => state.isChecked);
+    const toggleCleanCheckbox = useStore((state) => state.toggleChecked);
+    const fromSynBioHub = useStore(s => s.fromSynBioHub)
 
 
     const AnnotationCheckboxContainer = forwardRef((props, ref) => (
@@ -321,6 +325,9 @@ function Annotations({ colors }) {
                     setSequencePartLibrariesSelected(...librariesSelected);
                 })}               
             />
+            { fromSynBioHub &&
+                <Checkbox label="Clean SynBioHub URIs" checked={isChecked} onChange={toggleCleanCheckbox} style={{ margin: '10px 10px 5px 5px' }}/>
+            }
 
             {loading ?
                 <Center>
@@ -334,7 +341,8 @@ function Annotations({ colors }) {
                     color="blue"
                     onClick={handleAnalyzeSequenceClick}
                     sx={{ borderRadius: 6 }}
-               />}
+               />
+            }
         </FormSection>
     )
 }

--- a/apps/web/src/modules/api.js
+++ b/apps/web/src/modules/api.js
@@ -71,7 +71,7 @@ export async function fetchSBOL(url) {
     }
 }
 
-export async function fetchAnnotateSequence({ sbolContent, selectedLibraryFileNames }) {
+export async function fetchAnnotateSequence({ sbolContent, selectedLibraryFileNames, isChecked }) {
     console.log("Annotating sequence...")
 
     // Fetch
@@ -84,6 +84,7 @@ export async function fetchAnnotateSequence({ sbolContent, selectedLibraryFileNa
             body: JSON.stringify({
                 completeSbolContent: sbolContent,
                 partLibraries: selectedLibraryFileNames,
+                cleanURIs: isChecked,
             }),
             timeout: 120000,
         });

--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -3,6 +3,7 @@ import { Graph, S2ComponentDefinition, S2ComponentInstance, SBOL2GraphView } fro
 import { TextBuffer } from "text-ranger"
 import { mutateDocument, useAsyncLoader, useStore } from "./store"
 
+//change to seqimprove.synbiohub.org?
 const Prefix = "https://seqimprove.org/"
 
 const Predicates = {
@@ -200,7 +201,7 @@ export function hasSequenceAnnotationSBOL(componentDefinition, annotationId) {
   * @param {array} sequenceAnnotations
  */
 export function removeDuplicateComponentAnnotation(componentDefinition, id) {
-    console.log(id)
+    console.log("removing: " + id)
     if (!hasSequenceAnnotationSBOL(componentDefinition, id))
         return
 
@@ -233,6 +234,13 @@ export function removeAnnotationWithDefinition(componentDefinition, id) {
     annotation.destroy()
     associatedComponent.destroy()
     definition.destroy()
+}
+
+export function cleanDownload(componentDefinition) {
+    const version = Number(componentDefinition.version)
+    // console.log("version = " + version)
+
+    componentDefinition.version = version + 1
 }
 
 /**

--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -137,6 +137,8 @@ export async function createSBOLDocument(sbolContent) {
 
 export function isfromSynBioHub(componentDefinition) {
     if (componentDefinition.uriChain.includes('https://synbiohub.org')) return true
+
+    return false
 }
 
 /**

--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -135,6 +135,10 @@ export async function createSBOLDocument(sbolContent) {
     return document
 }
 
+export function isfromSynBioHub(componentDefinition) {
+    if (componentDefinition.uriChain.includes('https://synbiohub.org')) return true
+}
+
 /**
  * Return the active status of any annotation in the sequenceAnnotations array
  *

--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -236,7 +236,7 @@ export function removeAnnotationWithDefinition(componentDefinition, id) {
     definition.destroy()
 }
 
-export function cleanDownload(componentDefinition) {
+export function incrementVersion(componentDefinition) {
     const version = Number(componentDefinition.version)
     // console.log("version = " + version)
 

--- a/apps/web/src/modules/store.js
+++ b/apps/web/src/modules/store.js
@@ -2,7 +2,7 @@ import _, { remove } from "lodash"
 import create from "zustand"
 import produce from "immer"
 import { getSearchParams, showErrorNotification } from "./util"
-import { addSequenceAnnotation, addTextAnnotation, createSBOLDocument, getExistingSequenceAnnotations, hasSequenceAnnotation, hasTextAnnotation, parseTextAnnotations, removeAnnotationWithDefinition, removeDuplicateComponentAnnotation, removeSequenceAnnotation, removeTextAnnotation } from "./sbol"
+import { addSequenceAnnotation, addTextAnnotation, incrementVersion, createSBOLDocument, getExistingSequenceAnnotations, hasSequenceAnnotation, hasTextAnnotation, parseTextAnnotations, removeAnnotationWithDefinition, removeDuplicateComponentAnnotation, removeSequenceAnnotation, removeTextAnnotation } from "./sbol"
 import { fetchAnnotateSequence, fetchAnnotateText, fetchSBOL } from "./api"
 import { SBOL2GraphView } from "sbolgraph"
 import fileDownload from "js-file-download"
@@ -150,7 +150,6 @@ export const useStore = create((set, get) => ({
 
         //remove duplicate annotation and component instance
         for (const rootAnno of get().document.root.sequenceAnnotations) {
-            console.log(rootAnno.persistentIdentity)
             for (const anno of annotations) {
                 if (rootAnno.persistentIdentity && (anno.id.slice(0, -2) === rootAnno.persistentIdentity.slice(0, -2) && rootAnno.persistentIdentity.slice(-1) >= 2)) { //potential bug: persistentIdentities may match but locations are different. The second instance will be removed if the part appears multiple times in the sequence
                     console.log("duplicate: " + rootAnno.persistentIdentity)
@@ -165,6 +164,9 @@ export const useStore = create((set, get) => ({
             console.log(anno.id + " enabled=" + anno.enabled)
             if (!anno.enabled) removeAnnotationWithDefinition(get().document.root, anno.id)
         }
+
+        //change version
+        incrementVersion(get().document.root)
 
         const xml = get().document.serializeXML();
         

--- a/apps/web/src/modules/store.js
+++ b/apps/web/src/modules/store.js
@@ -156,7 +156,7 @@ export const useStore = create((set, get) => ({
         }
 
         //change version
-        incrementVersion(get().document.root)
+        if (get().fromSynBioHub) incrementVersion(get().document.root)
 
         const xml = get().document.serializeXML();
         


### PR DESCRIPTION
#9 Added support for 'clean' downloads. If synbiohub uri is detected, an option to 'clean' the uri appears in the analyze sequence selection box. This changes all references to synbiohub.org to instead use seqimprove.synbiohub.org, allowing reuploads of now annotated synbiohub parts.

Version is incremented if synbiohub uri

#88 added overwrite checkbox to synbiohub upload to new collection from seqimprove