### PR TITLE
duplicate annotation removal fix

### DIFF
--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -200,16 +200,20 @@ export function hasSequenceAnnotationSBOL(componentDefinition, annotationId) {
   * @param {array} sequenceAnnotations
  */
 export function removeDuplicateComponentAnnotation(componentDefinition, id) {
-    console.log(id)
     if (!hasSequenceAnnotationSBOL(componentDefinition, id))
         return
 
+    const duplicateAnnotation = componentDefinition.sequenceAnnotations.find(sa => sa.persistentIdentity == id)
+    const associatedComponent = duplicateAnnotation.component
 
-    const annotation = componentDefinition.sequenceAnnotations.find(sa => sa.persistentIdentity == id)
-    const associatedComponent = annotation.component
+    const origIdNum = Number(id.slice(-1)) - 1 
+    const originalAnnotation = componentDefinition.sequenceAnnotations.find(sa => sa.persistentIdentity == id.slice(0, -1) + origIdNum)
 
-    annotation.destroy()
-    associatedComponent.destroy()
+    if (originalAnnotation.rangeMax === duplicateAnnotation.rangeMax && originalAnnotation.rangeMin === duplicateAnnotation.rangeMin) {
+        console.log("removing duplicate annotation: " + duplicateAnnotation.displayId)
+        duplicateAnnotation.destroy()
+        associatedComponent.destroy()
+    }
 }
 
 /**

--- a/apps/web/src/modules/store.js
+++ b/apps/web/src/modules/store.js
@@ -150,10 +150,8 @@ export const useStore = create((set, get) => ({
 
         //remove duplicate annotation and component instance
         for (const rootAnno of get().document.root.sequenceAnnotations) {
-            console.log(rootAnno.persistentIdentity)
             for (const anno of annotations) {
                 if (rootAnno.persistentIdentity && (anno.id.slice(0, -2) === rootAnno.persistentIdentity.slice(0, -2) && rootAnno.persistentIdentity.slice(-1) >= 2)) { //potential bug: persistentIdentities may match but locations are different. The second instance will be removed if the part appears multiple times in the sequence
-                    console.log("duplicate: " + rootAnno.persistentIdentity)
                     removeDuplicateComponentAnnotation(get().document.root, rootAnno.persistentIdentity)
                 }
             }
@@ -162,7 +160,6 @@ export const useStore = create((set, get) => ({
 
         //if disabled(in annos array but enabled=false), REMOVE: component & sequence annotation (children of root component definition), component definition, associated sequence
         for (const anno of annotations) {
-            console.log(anno.id + " enabled=" + anno.enabled)
             if (!anno.enabled) removeAnnotationWithDefinition(get().document.root, anno.id)
         }
 


### PR DESCRIPTION
closes #92 

Previously: duplicate annotations would be removed if they had the same persistent id, leading to removal of annotations in sequences that might've used the same promoter or terminator twice.

Now: duplicate annos now only removed if they have equal ranges as well as id's