### PR TITLE
component role editing

### DIFF
--- a/apps/web/src/components/RoleSelection.jsx
+++ b/apps/web/src/components/RoleSelection.jsx
@@ -89,7 +89,7 @@ function Role({ idx }) {
                     styles={selectStyles}
                     sx={{ flexGrow: 1, }}
                 />
-                <CloseButton iconSize={20} onClick={removeRole} />
+                {/* <CloseButton iconSize={20} onClick={removeRole} /> */}
             </Group>
             <Space h="lg" />
         </div>
@@ -104,7 +104,7 @@ export default function RoleSelection() {
     };
     
     return roles.map((_, idx) =>
-        <Role key={idx} idx={idx} />).concat(<Button key={'a'} onClick={addRoleHandler}>Add Role</Button>);
+        <Role key={idx} idx={idx} />);
 }
 
 const RoleItem = forwardRef(({ label, shortId, ...others }, ref) =>

--- a/apps/web/src/modules/store.js
+++ b/apps/web/src/modules/store.js
@@ -62,12 +62,16 @@ export const useStore = create((set, get) => ({
             document.root.description = richDescriptionBuffer.originalText;
 
             // set roles to be the same as from document
-            const roles = document.root.roles;            
+            if(document.root.roles.length < 1) document.root.roles = ["http://identifiers.org/so/SO:0000804"] //default to engineered region
+            const roles = document.root.roles;   
+            
             
             const fromSynBioHub = isfromSynBioHub(document.root); 
             let isFileEdited = false
             let isUriCleaned = false
             let nameChanged = false
+
+            if (document.root.uriChain.includes("https://seqimprove.synbiohub.org")) isUriCleaned = true
 
             set({
                 // ...result,


### PR DESCRIPTION
closes #95

removed add and delete role buttons, now defaults to engineered region
users can only change role using dropdown, and a component can only have one role

additionally, if uri is already from seqimprove, then uri will not be cleaned