### PR TITLE
Corrected sequence highlighter to convert 1-based SBOL indices

### DIFF
--- a/apps/server/assets/scripts/get_annotations/get_annotations.js
+++ b/apps/server/assets/scripts/get_annotations/get_annotations.js
@@ -28,7 +28,7 @@ const FilePathOriginal = process.argv[3];
         .map(sa => ({
             name: sa.displayName,
             id: sa.persistentIdentity,
-            location: [sa.rangeMin, sa.rangeMax],
+            location: [sa.rangeMin - 1, sa.rangeMax], // convert to 0 based indexing to match javascript array indices
         }))));
 })();
 

--- a/apps/web/src/modules/api.js
+++ b/apps/web/src/modules/api.js
@@ -236,7 +236,7 @@ export async function fetchAnnotateSequence({ sbolContent, selectedLibraryFileNa
                                              .map(sa => ({
                                                  name: sa.displayName,
                                                  id: sa.persistentIdentity,
-                                                 location: [sa.rangeMin, sa.rangeMax],
+                                                 location: [sa.rangeMin - 1, sa.rangeMax], // convert to 0 based indexing to match javascript array indices
                                                  componentInstance: sa.component,
                                                  featureLibrary: sa.component.definition.persistentIdentity,
                                                  enabled: true,

--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -265,7 +265,7 @@ export function getExistingSequenceAnnotations(componentDefinition) {
     return componentDefinition.sequenceAnnotations.map(sa => ({
         id: sa.persistentIdentity,
         name: sa.displayName,
-        location: [sa.locations[0].start, sa.locations[0].end],
+        location: [sa.locations[0].start - 1, sa.locations[0].end], // convert to 0 based indexing to match javascript array indices
     }))
 }
 


### PR DESCRIPTION
Closes #119 
- Corrected the sequence highlighter to start at index 0 instead of index 1, which was causing it to miss the first letter in the sequence.