### PR TITLE
update create collection submissions to use a dynamic url prefix

### DIFF
--- a/apps/web/src/components/CurationForm.jsx
+++ b/apps/web/src/components/CurationForm.jsx
@@ -191,10 +191,10 @@ function SynBioHubClientUpload({ setIsInteractingWithSynBioHub }) {
                          onChange={(e) => {
                              const str = e.currentTarget.value;
                              setID(e.currentTarget.value);
-                             if (str.match(/^\w+$/)) {                                     
+                             if (str.match(/^[a-zA-Z_]\w*$/)) {                                     
                                  setInputErrorID(false);
                              } else {
-                                 setInputErrorID("Invalid id");
+                                 setInputErrorID("Invalid id - must start with letter or underscore");
                              }                                 
                          }}
                          withAsterisk
@@ -258,7 +258,7 @@ function SynBioHubClientUpload({ setIsInteractingWithSynBioHub }) {
                                      // Create a Blob from the text
                                      const blob = new Blob([xml], { type: 'text/plain' });
                                      params.append('file', blob, 'file.txt');
-                                     const url = "https:/" + "/synbiohub.org/submit";
+                                     const url = synBioHubUrlPrefix + "/submit"; // submit to dynamic url prefix
 
                                      setIsLoading(true);
                                      const response = await fetch(url, {
@@ -314,7 +314,7 @@ function SynBioHubClientUpload({ setIsInteractingWithSynBioHub }) {
                                   // Create a Blob from the text
                                   const blob = new Blob([xml], { type: 'text/plain' });
                                   params.append('file', blob, 'example.txt');
-                                  const url = "https:/" + "/synbiohub.org/submit";
+                                  const url = synBioHubUrlPrefix + "/submit"; // submit to dynamic url prefix
 
                                   setIsLoading(true);
                                   const response = await fetch(url, {

--- a/apps/web/src/modules/api.js
+++ b/apps/web/src/modules/api.js
@@ -28,7 +28,7 @@ export async function fetchConvertGenbankToSBOL2(genbankContent) {
                 },
                 body: JSON.stringify({
                     GenBankContent: genbankContent,
-                    uriPrefix: "https://seqimprove.synbiohub.org",
+                    uriPrefix: sessionStorage.getItem("synBioHubUrlPrefix"), // dynamic url prefix
                 }),
                 timeout: count * 1000,
             });

--- a/apps/web/src/modules/store.js
+++ b/apps/web/src/modules/store.js
@@ -74,7 +74,7 @@ export const useStore = create((set, get) => ({
             let isUriCleaned = false
             let nameChanged = false
 
-            if (document.root.uriChain.includes("https://seqimprove.synbiohub.org")) isUriCleaned = true
+            if (document.root.uriChain.includes("https://seqimprove.synbiohub.org") || document.root.uriChain.includes("https://charmme.synbiohub.org")) isUriCleaned = true
 
             set({
                 // ...result,


### PR DESCRIPTION
Closes #121 
- Updated submit requests to use the selected URL (ex. charmme.synbiohub.org) rather than being hardcoded to synbiohub.org.
- Created an explicit error message for invalid collection ID.