### PR TITLE
Allow editing the name of sbol documents

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -269,6 +269,7 @@ def run_biobert(text):
             accum[id] = {
                 'id': find_ontology_link(id),
                 'displayId': id,
+                'title': anno['title'],
                 'mentions': mentions + [{
                     'text': anno['mention'],
                     'confidence': anno['prob'],

--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -463,6 +463,43 @@ def remove_library():
 
     return {"response": "Library successfully deleted"}
 
+@app.post("/api/updateDocumentProperties")
+def update_document_properties():
+    request_data = request.get_json()
+    sbol_content = request_data['sbolContent']
+    new_title = request_data.get('title')
+    new_display_id = request_data.get('displayId')
+
+    try:
+        # create SBOL document using Python sbol2 library
+        doc = sbol2.Document()
+        doc.readString(sbol_content)
+        
+        # get the root component definition
+        if len(doc.componentDefinitions) > 0:
+            root_component = doc.componentDefinitions[0]
+            
+            # update displayId if provided
+            if new_display_id is not None:
+                root_component.displayId = new_display_id
+            
+            # update title if provided, otherwise set to display ID
+            if new_title is not None:
+                root_component.name = new_title
+            elif not root_component.name:
+                # if no title exists, set it to the display ID
+                root_component.name = root_component.displayId
+            
+            # return the updated SBOL content
+            updated_sbol = doc.writeString()
+            return {"sbolContent": updated_sbol, "error": ""}
+        else:
+            return {"sbolContent": "", "error": "No component definitions found in document"}
+            
+    except Exception as e:
+        print(f"Error updating document properties: {str(e)}")
+        return {"sbolContent": "", "error": f"Failed to update document: {str(e)}"}
+
 # if __name__ == '__main__':
 #     app.run(debug=True,host='0.0.0.0',port=5000)
 if __name__ == "__main__":    

--- a/apps/web/src/components/CurationForm.jsx
+++ b/apps/web/src/components/CurationForm.jsx
@@ -20,6 +20,7 @@ import { useState } from "react"
 import { showErrorNotification, showNotificationSuccess } from "../modules/util"
 import { Graph, SBOL2GraphView } from "sbolgraph"
 import { createSBOLDocument } from '../modules/sbol'
+import { updateDocumentProperties } from '../modules/api'
 
 function validDisplayID(displayID) {
     return displayID.match(/^[a-z_]\w+$/i);
@@ -390,7 +391,7 @@ export default function CurationForm({ }) {
         setWorkingDisplayID(displayId);
     };
     
-    const handleEndNameEdit = (cancelled = false) => {
+    const handleEndNameEdit = async (cancelled = false) => {
         if (cancelled) {
             setIsEditingName(false);
             return;
@@ -408,90 +409,18 @@ export default function CurationForm({ }) {
 
         setIsEditingName(false);       
 
+        // use Python sbol2 library via API
+        const sbolContent = useStore.getState().sbolContent;
+        const result = await updateDocumentProperties(sbolContent, workingName, workingDisplayID);
+        
+        if (result.error) {
+            showErrorNotification("Failed to update document", result.error);
+            return;
+        }
+
+        // Update the document with the new SBOL content
         mutateDocumentForDisplayID(useStore.setState, async state => {
-            // handle dcterms:title in XML
-            let remainingXML = state.document.serializeXML();
-            let xmlChunks = [];
-            
-            // check if dcterms:title exists and replace it, or create it if it doesn't exist
-            const regexpOpenTitleTag = /\<dcterms\:title\>/;
-            const regexpCloseTitleTag = /\<\/dcterms\:title\>/;
-            let matchData = remainingXML.match(regexpOpenTitleTag);            
-
-            if (matchData) {
-                // dcterms:title exists, replace it
-                while(matchData) {
-                    xmlChunks.push(remainingXML.slice(0, matchData.index + matchData[0].length));
-                    remainingXML = remainingXML.slice(matchData.index + matchData[0].length);
-
-                    const closeMatch = remainingXML.match(regexpCloseTitleTag);
-                    xmlChunks.push(workingName);
-
-                    remainingXML = remainingXML.slice(closeMatch.index);
-                    matchData = remainingXML.match(regexpOpenTitleTag);
-                }
-            } else {
-                // dcterms:title doesn't exist, create it after <sbol:version>
-                const versionTagRegex = /(\<sbol\:version\>.*?\<\/sbol\:version\>)/;
-                const versionMatch = remainingXML.match(versionTagRegex);
-                
-                if (versionMatch) {
-                    const insertIndex = versionMatch.index + versionMatch[0].length;
-                    xmlChunks.push(remainingXML.slice(0, insertIndex));
-                    xmlChunks.push(`\n    <dcterms:title>${workingName}</dcterms:title>`);
-                    remainingXML = remainingXML.slice(insertIndex);
-                } else {
-                    // fallback: insert after displayId if version not found
-                    const displayIdTagRegex = /(\<sbol\:displayId\>.*?\<\/sbol\:displayId\>)/;
-                    const displayIdMatch = remainingXML.match(displayIdTagRegex);
-                    
-                    if (displayIdMatch) {
-                        const insertIndex = displayIdMatch.index + displayIdMatch[0].length;
-                        xmlChunks.push(remainingXML.slice(0, insertIndex));
-                        xmlChunks.push(`\n    <dcterms:title>${workingName}</dcterms:title>`);
-                        remainingXML = remainingXML.slice(insertIndex);
-                    }
-                }
-            }
-
-            // handle displayID changes in the combined XML
-            remainingXML = xmlChunks.concat(remainingXML).join('');
-            xmlChunks = [];
-            
-            // replace displayId in URIs in xml            
-            let matchDataURI = remainingXML.match(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/);
-
-            while (matchDataURI) {
-                xmlChunks.push(remainingXML.slice(0,matchDataURI.index));                
-                const uri = matchDataURI[0];
-                const regexp = new RegExp(state.document.root.displayId, 'g');
-                xmlChunks.push(uri.replace(regexp, workingDisplayID));
-
-                remainingXML = remainingXML.slice(matchDataURI.index + uri.length);                
-                matchDataURI = remainingXML.match(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/);
-            }
-
-            // Replace displayId property in xml
-            remainingXML = xmlChunks.concat(remainingXML).join('');                      
-            xmlChunks = [];
-            const regexpOpenTag = /\<sbol\:displayId\>/;
-            const regexpCloseTag = /\<\/sbol\:displayId\>/;
-            matchData = remainingXML.match(regexpOpenTag);            
-
-            while(matchData) {
-                xmlChunks.push(remainingXML.slice(0, matchData.index + matchData[0].length));
-                remainingXML = remainingXML.slice(matchData.index + matchData[0].length);
-
-                matchData = remainingXML.match(regexpCloseTag);
-                xmlChunks.push(workingDisplayID);
-
-                remainingXML = remainingXML.slice(remainingXML.match(regexpCloseTag).index);
-                matchData = remainingXML.match(regexpOpenTag);
-            }
-
-            const newSBOLcontent = xmlChunks.concat(remainingXML).join('');
-
-            await state.replaceDocumentForIDChange(newSBOLcontent);      
+            await state.replaceDocumentForIDChange(result.sbolContent);
         });
     };
         
@@ -527,6 +456,19 @@ export default function CurationForm({ }) {
                                 {isEditingName ?
                                  <Group direction="column" spacing={12}>
                                      <Group spacing={0} align="flex-start">
+                                         <Text size="xs" color="dimmed" mb={4}>Display ID</Text>
+                                     </Group>
+                                     <Textarea
+                                         autosize
+                                         maxrows={1}
+                                         value={workingDisplayID}
+                                         onChange={event => {
+                                             setWorkingDisplayID(event.currentTarget.value);
+                                         }}
+                                         styles={{ input: { font: "18px monospace" } }}
+                                         placeholder="Display ID"
+                                     />
+                                     <Group spacing={0} align="flex-start">
                                          <Text size="xs" color="dimmed" mb={4}>Name</Text>
                                      </Group>
                                      <Textarea
@@ -539,20 +481,8 @@ export default function CurationForm({ }) {
                                          styles={{ input: { font: "18px monospace" } }}
                                          placeholder="Document name"
                                      />
-                                     <Group spacing={0} align="flex-start">
-                                         <Text size="xs" color="dimmed" mb={4}>Display ID</Text>
-                                     </Group>
-                                     <Textarea
-                                         autosize
-                                         maxrows={1}
-                                         value={workingDisplayID}
-                                         onChange={event => {
-                                             setWorkingDisplayID(event.currentTarget.value);
-                                         }}
-                                         styles={{ input: { font: "18px monospace" } }}
-                                     />
                                  </Group> :
-                                 <Title order={3}>{name}</Title>
+                                 <Title order={3}>{displayId}</Title>
                                 }                                
                                 {isEditingName ? 
                                  <Group spacing={6}>

--- a/apps/web/src/modules/api.js
+++ b/apps/web/src/modules/api.js
@@ -320,6 +320,44 @@ export async function fetchSimilarParts(topLevelUri) {
     return result.similarParts
 }
 
+export async function updateDocumentProperties(sbolContent, title, displayId) {
+    try {
+        var response = await fetchWithTimeout(`${import.meta.env.VITE_API_LOCATION}/api/updateDocumentProperties`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+                sbolContent: sbolContent,
+                title: title,
+                displayId: displayId
+            }),
+            timeout: 30000,
+        });
+    }
+    catch (err) {
+        console.error("Failed to fetch.");
+        showServerErrorNotification();
+        return { sbolContent: "", error: "Network error" };
+    }
+
+    try {
+        var result = await response.json();
+    }
+    catch (err) {
+        console.error("Couldn't parse JSON.");
+        showServerErrorNotification();
+        return { sbolContent: "", error: "Parse error" };
+    }
+
+    if (response.status == 200) {
+        console.log("Document properties updated successfully.");
+        return result;
+    } else {
+        return { sbolContent: "", error: result.error || "Server error" };
+    }
+}
+
 async function fetchWithTimeout(resource, options = {}) {
     const { timeout = 8000 } = options;
     

--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -45,6 +45,11 @@ Object.defineProperties(S2ComponentDefinition.prototype, {
         set(value) { this.setStringProperty(Predicates.RichDescription, value) },
     },
 
+    title: {
+        get() { return this.getStringProperty("http://purl.org/dc/terms/title") },
+        set(value) { this.setStringProperty("http://purl.org/dc/terms/title", value) },
+    },
+
     // role: {
     //     get() { return this.roles[0] },
     //     set(value) {

--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -137,6 +137,11 @@ export async function createSBOLDocument(sbolContent) {
         document.root.richDescription = document.root.description
     }
     
+    // initialize title as display ID if one doesn't exist
+    if (!document.root.title) {
+        document.root.title = document.root.displayId
+    }
+    
     return document
 }
 

--- a/apps/web/src/modules/store.js
+++ b/apps/web/src/modules/store.js
@@ -452,6 +452,13 @@ export function mutateDocumentForDisplayID(set, mutator) {
     });
 }
 
+export function mutateDocumentForName(set, mutator) {
+    set(state => {
+        mutator?.(state);
+        return { document: state.document };
+    });
+}
+
 export function mutateSequencePartLibrariesSelected(set, mutator) {
     set(state => {
         mutator(state);


### PR DESCRIPTION
Closes #118 
- Created an API endpoint to manipulate name and display id using the Python sbol2 library.
- Created frontend API function that calls the server API endpoint.
- If SBOL document does not have a name, the dcterms:title (name) is created and defaulted to the display id.
- Added ability to edit the document name alongside display id.
- Moved export document and log out buttons inside the navbar component so they format cleanly when name/display id text boxes open.