### PR TITLE
fix missing title field in BioBERT annotations

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -269,7 +269,7 @@ def run_biobert(text):
             accum[id] = {
                 'id': find_ontology_link(id),
                 'displayId': id,
-                'title': anno['title'],
+                'title': anno.get('title', 'Unknown'),
                 'mentions': mentions + [{
                     'text': anno['mention'],
                     'confidence': anno['prob'],


### PR DESCRIPTION
Closes #133 
- Replaced direct dictionary access with .get() method and fallback value to handle missing `title` field in BioBERT service responses