### PR TITLE
properly save both displayid and uris before export to synbiohub

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -29,12 +29,12 @@ export default function App() {
         paramsUri && loadSBOL(paramsUri, FILE_TYPES.URL)
     }, [isFileEdited]);
 
-    //name change effect
-    useEffect(() => {
-        if (nameChanged && !isUriCleaned) {
-            cleanSBOLDocument();
-        }
-    }, [nameChanged])
+    // name change effect - disabled to prevent displayId from being reset
+    // useEffect(() => {
+    //     if (nameChanged && !isUriCleaned) {
+    //         cleanSBOLDocument();
+    //     }
+    // }, [nameChanged])
 
 
     // load SBOL into store if we have a complete_sbol parameter


### PR DESCRIPTION
Closes #137 
## Issues Fixed

  - DisplayId changes would reset to original value after ~5 seconds due to automatic URI cleaning triggered by name changes
  - DisplayId edits were not persisted when exporting to SynBioHub, causing uploads to use old displayId values
  - SBOL document URIs were inconsistent when displayId was updated (displayId tag updated but rdf:about and persistentIdentity URIs remained unchanged)

  ## Fixes and Restored Functionality

  - Disabled automatic SBOL document cleaning on name changes to prevent displayId reversion
  - Added automatic saving of pending displayId/name edits before SynBioHub export to ensure current values are used
  - Implemented comprehensive URI consistency updates in server-side document processing to ensure all SBOL URIs match the updated displayId
  - DisplayId and name changes now persist correctly in UI and are maintained through SynBioHub export process