### PR TITLE
fix: resolve library import failures, error handling, and better logging

### DIFF
--- a/apps/server/app.py
+++ b/apps/server/app.py
@@ -7,6 +7,9 @@ import sbol2
 import logging
 import os
 import asyncio
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
+logger = logging.getLogger(__name__)
 import json
 import subprocess
 import tempfile
@@ -84,7 +87,8 @@ def setup():
         feature_doc = sbol2.Document()
         feature_doc.read(feature_library_path)
         # FEATURE_LIBRARIES.append([feature_library_path, FeatureLibrary([feature_doc])])
-        FEATURE_LIBRARIES[feature_library_path] = FeatureLibrary([feature_doc])
+        abs_path = os.path.abspath(feature_library_path)
+        FEATURE_LIBRARIES[abs_path] = FeatureLibrary([feature_doc])
 
     # check for new libraries in synbiohub.org/rootcollections, pull if any exist
     #
@@ -125,7 +129,10 @@ def create_feature_library(part_library_file_name):
                 part_library_file_name = sbh_file_prefixes[uri_index] + '.xml'
 
     feature_libraries_dir = "./assets/synbict/feature-libraries"
-    feature_library_path = os.path.join(feature_libraries_dir, part_library_file_name)
+    feature_library_path = os.path.abspath(os.path.join(feature_libraries_dir, part_library_file_name))
+    if feature_library_path not in FEATURE_LIBRARIES:
+        raise KeyError(f"Library not found in cache: '{part_library_file_name}'. "
+                       f"It may have been deleted. Available libraries: {list(FEATURE_LIBRARIES.keys())}")
     return FEATURE_LIBRARIES[feature_library_path]
 
 def sbh_pull_library(uri):
@@ -183,8 +190,8 @@ def run_synbict(sbol_content: str, part_library_file_names: list[str]) -> tuple[
         target_doc = sbol2.Document()
         try:
             target_doc.readString(sbol_content)
-        except Exception:
-            print('Could not parse sbol_content')    
+        except Exception as e:
+            logger.error(f"Could not parse sbol_content: {e}", exc_info=True)
             return status.HTTP_400_BAD_REQUEST, 'Could not parse sbol_content', None
         else:
             # Create a temporary file
@@ -437,6 +444,8 @@ def annotate_sequence():
     sbol_content = request_data['completeSbolContent']
     part_library_file_names = request_data['partLibraries'] 
     clean_document = request_data['cleanDocument']
+    logger.info(f"Annotation request: libraries={part_library_file_names}, clean={clean_document}")
+    logger.info(f"Available FEATURE_LIBRARIES keys: {list(FEATURE_LIBRARIES.keys())}")
 
     if clean_document: 
         sbol_content = run_synbio2easy(sbol_content)
@@ -455,9 +464,8 @@ def annotate_sequence():
             return {"sbol": sbol_content, "error_message": error_message}, error_code
         
     except Exception as e:
-        print("Caught exception")
-        print(str(e))
-        return {"sbol": sbol_content}, status.HTTP_500_INTERNAL_SERVER_ERROR
+        logger.error(f"Annotation failed for libraries={part_library_file_names}: {e}", exc_info=True)
+        return {"sbol": sbol_content, "error_message": str(e)}, status.HTTP_500_INTERNAL_SERVER_ERROR
     else:
         return {"annotations": anno_lib_assoc}
 
@@ -485,29 +493,39 @@ def import_library():
         "X-authorization": SBHSessionToken
     }
 
-    response = requests.get(collectionURL, headers=headers)
+    logger.info(f"Importing library from: {collectionURL}")
+    try:
+        response = requests.get(collectionURL, headers=headers, timeout=60)
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to connect to SynBioHub for '{collectionURL}': {e}")
+        return {"error": f"Could not connect to SynBioHub: {e}"}, status.HTTP_502_BAD_GATEWAY
 
     # Check if the request was successful
     if response.status_code == 200:
-        feature_doc = sbol2.Document()
-        feature_doc.readString(response.text)
-        FEATURE_LIBRARIES[collectionURL] = FeatureLibrary([feature_doc])
-        print(f"all libraries: {FEATURE_LIBRARIES.keys()}")
-        
-        return {"response": response.text}
+        try:
+            feature_doc = sbol2.Document()
+            feature_doc.readString(response.text)
+            FEATURE_LIBRARIES[collectionURL] = FeatureLibrary([feature_doc])
+            logger.info(f"Imported library '{collectionURL}'. All libraries: {list(FEATURE_LIBRARIES.keys())}")
+            return {"response": response.text}
+        except Exception as e:
+            logger.error(f"Failed to parse SBOL from '{collectionURL}': {e}", exc_info=True)
+            return {"error": f"Failed to parse library SBOL: {e}"}, status.HTTP_500_INTERNAL_SERVER_ERROR
     else:
-        print(f"Request failed with status code: {response.status_code}")
-        return {"response": response.text}
+        logger.error(f"Failed to import library '{collectionURL}': HTTP {response.status_code}")
+        return {"error": f"SynBioHub returned HTTP {response.status_code}"}, response.status_code
 
 @app.post("/api/deleteUserLibrary")
 def remove_library():
     request_data = request.get_json()
     collectionURL = request_data['url']
 
-    if FEATURE_LIBRARIES[collectionURL]: del FEATURE_LIBRARIES[collectionURL]
-    else: return {"response": "Library does not exist"}
-
-    print(f"\nupdated libraries: {FEATURE_LIBRARIES.keys()}")
+    if collectionURL in FEATURE_LIBRARIES:
+        del FEATURE_LIBRARIES[collectionURL]
+        logger.info(f"Deleted library '{collectionURL}'. Remaining: {list(FEATURE_LIBRARIES.keys())}")
+    else:
+        logger.warning(f"Attempted to delete library not in cache: '{collectionURL}'. Available: {list(FEATURE_LIBRARIES.keys())}")
+        return {"response": "Library does not exist"}
 
     return {"response": "Library successfully deleted"}
 

--- a/apps/web/src/components/CurationForm.jsx
+++ b/apps/web/src/components/CurationForm.jsx
@@ -163,7 +163,10 @@ function SynBioHubClientUpload({ setIsInteractingWithSynBioHub, isEditingName, h
             const _rootCollections = await response2.json();
             
             // const userRootCollections = _rootCollections.filter(collection => collection.uri.match(/https:\/\/synbiohub.org\/user\/*/));
-            let regex = RegExp(synBioHubUrlPrefix + "/user/*");
+            // SynBioHub URIs use the canonical domain (e.g. synbiohub.org) even when the API
+            // is accessed via api.synbiohub.org, so strip the api. subdomain before filtering.
+            const uriPrefix = synBioHubUrlPrefix.replace(/^(https?:\/\/)api\./, '$1');
+            let regex = RegExp(uriPrefix + "/user/*");
             const userRootCollections = _rootCollections.filter(collection => collection.uri.match(regex));
             setRootCollections(userRootCollections);
             setRootCollectionsIDs(userRootCollections.map(collection => collection.displayId));

--- a/apps/web/src/components/SequenceSection.jsx
+++ b/apps/web/src/components/SequenceSection.jsx
@@ -388,11 +388,11 @@ function Annotations({ colors }) {
                     <Loader my={30} size="sm" variant="dots" /> :
                 </Center>
              : <NavLink
-                    label="Analyze Sequence"
-                    icon={<FiDownloadCloud />}
+                    label={isImportingLibrary ? "Importing library, please wait..." : "Analyze Sequence"}
+                    icon={isImportingLibrary ? <Loader size="xs" /> : <FiDownloadCloud />}
                     variant="subtle"
                     active={true}
-                    color="blue"
+                    color={isImportingLibrary ? "gray" : "blue"}
                     disabled={isImportingLibrary}
                     onClick={handleAnalyzeSequenceClick}
                     sx={{ borderRadius: 6 }}
@@ -491,16 +491,16 @@ function SynBioHubClientSelect({ setIsInteractingWithSynBioHub, setIsImportingLi
                             params.append('rootCollections', rootCollectionURI);
                             // Create a Blob from the text
                             setIsLoading(true);
-                            const response = importLibrary(synBioHubSessionToken, rootCollectionURI, setIsImportingLibrary)                         
+                            const response = await importLibrary(synBioHubSessionToken, rootCollectionURI, setIsImportingLibrary)
 
+                            setIsInteractingWithSynBioHub(false);
                             if (response) {
                                 setInputError(false);
-                                setIsInteractingWithSynBioHub(false);
                                 showNotificationSuccess("Success!", "Imported Library: " + selectedCollectionID + ".");
                                 mutateDocument(useStore.setState, state => {state.libraryImported = true});
-                                addLibrary({ value: rootCollectionURI, label: selectedCollectionID, enabled: false})                                                                                                           
-                            } else {                                          
-                                showErrorNotification("Failure.", "SynBioHub did not accept the request");
+                                addLibrary({ value: rootCollectionURI, label: selectedCollectionID, enabled: false})
+                            } else {
+                                showErrorNotification("Import Failed", "Could not import library from SynBioHub. The server may be unreachable or your session may have expired. Try logging in again.");
                             }
                         }}>
                           Submit

--- a/apps/web/src/components/SequenceSection.jsx
+++ b/apps/web/src/components/SequenceSection.jsx
@@ -448,7 +448,10 @@ function SynBioHubClientSelect({ setIsInteractingWithSynBioHub, setIsImportingLi
 
             const _rootCollections = await response2.json();
             
-            let regex = RegExp(synBioHubUrlPrefix.replace(/^https?/, 'https?') + "/(?:user|public)/.*");
+            // SynBioHub URIs use the canonical domain (e.g. synbiohub.org) even when the API
+            // is accessed via api.synbiohub.org, so strip the api. subdomain before filtering.
+            const uriPrefix = synBioHubUrlPrefix.replace(/^(https?:\/\/)api\./, '$1');
+            let regex = RegExp(uriPrefix.replace(/^https?/, 'https?') + "/(?:user|public)/.*");
             const userRootCollections = _rootCollections.filter(collection => collection.uri.match(regex));
             setRootCollections(userRootCollections);
             setRootCollectionsIDs(userRootCollections.map(collection => collection.displayId));

--- a/apps/web/src/modules/api.js
+++ b/apps/web/src/modules/api.js
@@ -102,6 +102,14 @@ export async function importLibrary(synBioHubSessionToken, requestURL, setIsImpo
     } finally {
         setIsImportingLibrary(false);
     }
+
+    if (!response.ok || result.error) {
+        console.error("Library import failed:", result.error || response.statusText);
+        showServerErrorNotification();
+        return;
+    }
+
+    return result;
 }
 
 export async function deleteLibrary(libraryURL) {
@@ -203,12 +211,19 @@ export async function fetchAnnotateSequence({ sbolContent, selectedLibraryFileNa
         return;
     }
 
-    if (response.status == 200) {
-        console.log("Successfully annotated.");
+    if (!response.ok || result.error_message) {
+        const msg = result.error_message || `Server returned HTTP ${response.status}`;
+        console.error("Annotation failed:", msg);
+        throw new Error(msg);
     }
 
-    const annoLibsAssoc = result.annotations;    
-    
+    const annoLibsAssoc = result.annotations;
+
+    if (!annoLibsAssoc || annoLibsAssoc.length === 0) {
+        console.warn("No annotations returned from server:", result);
+        return { fetchedAnnotations: [], synbictDoc: null };
+    }
+
     // create and load original doc
     const originalDoc = new SBOL2GraphView(new Graph());
     await originalDoc.loadString(sbolContent);

--- a/apps/web/src/modules/store.js
+++ b/apps/web/src/modules/store.js
@@ -219,9 +219,9 @@ export const useStore = create((set, get) => ({
                 isUriCleaned: get().isUriCleaned,
             }) ?? [];
 
-            let { fetchedAnnotations, synbictDoc } = result;
+            let { fetchedAnnotations = [], synbictDoc } = result;
 
-            set({             
+            set({
                 sequenceAnnotations: produce(get().sequenceAnnotations, draft => {
                     fetchedAnnotations.forEach(anno => {
                         // skip duplicates
@@ -235,7 +235,8 @@ export const useStore = create((set, get) => ({
                 isUriCleaned: true,
             });
         } catch (err) {
-            showErrorNotification("Load Error", "Could not load sequence annotations");
+            const detail = err?.message || "The server encountered an error. A selected library may have failed to import — try removing it and re-importing.";
+            showErrorNotification("Annotation Error", detail);
             set({ loadingSequenceAnnotations: false });
         } finally {
             set({ loadingSequenceAnnotions: false });


### PR DESCRIPTION
## Summary
- Fixed silent import failures where the import function wasn't being awaited and never returned a result, so the UI always treated imports as successful even when the backend failed. The backend was also returning success responses on SynBioHub errors, which now returns proper error codes.
- Fixed a crash in the library removal endpoint where it tried to access a dictionary key directly instead of checking if it existed first. Deleting a library that was never saved to the python dict would crash the endpoint and break all subsequent annotation requests.
- Added structured logging with timestamps on the annotation, import, and delete endpoints. Previously errors were either swallowed by print statements or had no output at all.
- Improved frontend error handling so the annotation fetch now checks for failed responses and propagates backend error messages to the user. Added guards for undefined annotations and safe defaults to prevent crashes on empty responses.
- Small UX improvements: the Analyze button now shows a loading state with a spinner during import, the SynBioHub modal closes on failure instead of spinning forever, and error notifications show actionable messages instead of generic fallbacks.