### PR TITLE
Add SynBioSuite embed integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ yarn-error.log*
 auto-save-list
 tramp
 .\#*
+# local embed harness
+apps/web/test-embed.html

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -7,6 +7,7 @@ import { MantineProvider, Center, Box, Text, Space } from '@mantine/core'
 import { getSearchParams } from './modules/util'
 import { bootAPIserver } from "./modules/api"
 import { FILE_TYPES } from "./modules/fileTypes"
+import { isEmbedded, getInitialPayload, onEmbedChange, postToParent } from "./modules/embedded"
 
 export default function App() {
 
@@ -28,6 +29,21 @@ export default function App() {
         const paramsUri = getSearchParams().complete_sbol
         paramsUri && loadSBOL(paramsUri, FILE_TYPES.URL)
     }, [isFileEdited]);
+
+    useEffect(() => {
+        let handled = false
+        const consume = (data) => {
+            if (handled) return
+            handled = true
+            if (data?.sbol) {
+                loadSBOL(data.sbol, FILE_TYPES.SBOL2).finally(() => {
+                    postToParent("graphServiceLoadedSBOL")
+                })
+            }
+        }
+        if (isEmbedded()) consume(getInitialPayload())
+        return onEmbedChange(consume)
+    }, []);
 
     // name change effect - disabled to prevent displayId from being reset
     // useEffect(() => {

--- a/apps/web/src/components/CurationForm.jsx
+++ b/apps/web/src/components/CurationForm.jsx
@@ -1,6 +1,7 @@
 import { Container, Title, Tabs, Text, Space, LoadingOverlay, Button, Group, Header, List, ActionIcon, Tooltip, Textarea, Menu, Modal, TextInput, PasswordInput, Loader, Center, Select, SegmentedControl, Checkbox, TypographyStylesProvider } from '@mantine/core'
 import { useStore, mutateDocument, mutateDocumentForDisplayID } from '../modules/store'
-import { useCyclicalColors } from "../hooks/misc"
+import { useCyclicalColors, useIsEmbedded } from "../hooks/misc"
+import { postToParent } from "../modules/embedded"
 import SimilarParts from './SimilarParts'
 import RoleSelection from "./RoleSelection"
 import TypeSelection from "./TypeSelection"
@@ -15,7 +16,7 @@ import TextAnnotationModal from './TextAnnotationModal'
 import { TbDownload, TbUpload } from "react-icons/tb"
 import ReactMarkdown from 'react-markdown'
 import References from './References'
-import { FaHome, FaPencilAlt, FaTimes, FaCheck } from 'react-icons/fa'
+import { FaHome, FaPencilAlt, FaTimes, FaCheck, FaChevronDown } from 'react-icons/fa'
 import { useState } from "react"
 import { showErrorNotification, showNotificationSuccess } from "../modules/util"
 import { Graph, SBOL2GraphView } from "sbolgraph"
@@ -510,8 +511,29 @@ export default function CurationForm({ }) {
         });
     };
         
+    const embedded = useIsEmbedded();
+
+    const handleSaveToSuite = async () => {
+        if (sequence && !isValid(sequence)) {
+            showErrorNotification("SeqImprove only accepts DNA sequences with no ambiguities. Please submit a sequence with only ACTG bases.");
+            return;
+        }
+        try {
+            if (isEditingName) {
+                await handleEndNameEdit(false);
+            }
+            const sbol = useStore.getState().exportDocument(false);
+            postToParent({ sbol, source: "seqimprove" });
+            showNotificationSuccess("Saved to SynBioSuite", "Your SBOL was sent to the host app.");
+        } catch (err) {
+            const message = err?.message ?? String(err);
+            postToParent({ error: { message } });
+            showErrorNotification("Failed to save", message);
+        }
+    };
+
     const logout = useStore(s => s.logout);
-    const [ synBioHubs, setSynBioHubs ] = useState([]);    
+    const [ synBioHubs, setSynBioHubs ] = useState([]);
 
     const loadSynBioHubs = async () => {
         const response = await fetch("https://wor.synbiohub.org/instances");
@@ -524,14 +546,34 @@ export default function CurationForm({ }) {
         if (!sequence || typeof sequence !== 'string') {
             return false;
         }
-        
+
         const validChars = /^[actguryswkmbdhvnacdefghiklmnpqrstvwy.-\s]+$/i;
         if (sequence.match(validChars) === null) {
             return false;
         }
-        
+
         return true;
     }
+
+    const checkSequenceValidity = () => {
+        if (sequence && !isValid(sequence)) {
+            showErrorNotification("SeqImprove only accepts DNA sequences with no ambiguities. Please submit a sequence with only ACTG bases.");
+        }
+    };
+
+    const exportMenuItems = (!sequence || isValid(sequence)) && (
+        <Menu.Dropdown>
+            <Menu.Item onClick={exportDocument}>
+                Download SBOL2 {<TbDownload />}
+            </Menu.Item>
+            <Menu.Item onClick={() => {
+                loadSynBioHubs();
+                setIsInteractingWithSynBioHub(true);
+            }}>
+                Upload to SynBioHub {<TbUpload />}
+            </Menu.Item>
+        </Menu.Dropdown>
+    );
 
     return (
         <Tabs defaultValue="overview" variant="pills" styles={tabStyles}>
@@ -613,31 +655,41 @@ export default function CurationForm({ }) {
                                  Log out
                              </Button> :
                              <p></p>
-                            }                        
-                            <Menu shadow="md" width={200}>
-                                <Menu.Target>
-                                    <Button onClick={()=>{
-                                        // only show validation error if sequence exists but is invalid
-                                        // don't show error if sequence is just undefined/not loaded
-                                        if(sequence && !isValid(sequence)){
-                                            const errMessage = "SeqImprove only accepts DNA sequences with no ambiguities. Please submit a sequence with only ACTG bases."
-                                            showErrorNotification(errMessage);
-                                        }
-                                    }}>Export Document</Button>
-                                </Menu.Target>
-
-                                {(!sequence || isValid(sequence)) && <Menu.Dropdown> 
-                                    <Menu.Item onClick={exportDocument}> 
-                                        Download SBOL2 {<TbDownload />}
-                                    </Menu.Item>
-                                    <Menu.Item onClick={() => {
-                                                   loadSynBioHubs();
-                                                   setIsInteractingWithSynBioHub(true);
-                                               }}>
-                                        Upload to SynBioHub {<TbUpload />}
-                                    </Menu.Item>
-                                </Menu.Dropdown>}
-                            </Menu>
+                            }
+                            {embedded ? (
+                                <Group spacing={0}>
+                                    <Button
+                                        onClick={handleSaveToSuite}
+                                        sx={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
+                                    >
+                                        Save to Working Directory
+                                    </Button>
+                                    <Menu shadow="md" width={200}>
+                                        <Menu.Target>
+                                            <Button
+                                                onClick={checkSequenceValidity}
+                                                px={10}
+                                                sx={{
+                                                    borderTopLeftRadius: 0,
+                                                    borderBottomLeftRadius: 0,
+                                                    borderLeft: "1px solid rgba(255,255,255,0.35)",
+                                                }}
+                                                aria-label="More export options"
+                                            >
+                                                <FaChevronDown size={12} />
+                                            </Button>
+                                        </Menu.Target>
+                                        {exportMenuItems}
+                                    </Menu>
+                                </Group>
+                            ) : (
+                                <Menu shadow="md" width={200}>
+                                    <Menu.Target>
+                                        <Button onClick={checkSequenceValidity}>Export Document</Button>
+                                    </Menu.Target>
+                                    {exportMenuItems}
+                                </Menu>
+                            )}
                         </Group>
                         </Group>
                         </Container>

--- a/apps/web/src/hooks/misc.jsx
+++ b/apps/web/src/hooks/misc.jsx
@@ -1,9 +1,16 @@
 import { useMantineTheme } from "@mantine/core";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { generateCyclicalColors, getSearchParams } from "../modules/util";
+import { isEmbedded, onEmbedChange } from "../modules/embedded";
 
 export function useSearchParams() {
     return useMemo(() => getSearchParams(), [window.location.search])
+}
+
+export function useIsEmbedded() {
+    const [embedded, setEmbedded] = useState(isEmbedded());
+    useEffect(() => onEmbedChange(() => setEmbedded(isEmbedded())), []);
+    return embedded;
 }
 
 export function useRandomColor(level) {

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -3,8 +3,11 @@ import App from './App'
 import "./modules/store"
 // import "./index.css"
 import "./main.css"
+import { initEmbedListener } from "./modules/embedded"
 
-window.global = window 
+window.global = window
+
+initEmbedListener()
 
 ReactDOM.createRoot(document.getElementById('root')).render(
     <App />

--- a/apps/web/src/modules/embedded.js
+++ b/apps/web/src/modules/embedded.js
@@ -1,0 +1,39 @@
+// Embedded-mode detection for SeqImprove running inside SynBioSuite.
+//
+// the parent is captured from the first postMessage whose source is not our own
+// window. window.parent !== window is not reliable — it's also true when a page
+// is opened in a new tab via window.open, where there's an opener but no real
+// embedder. the handshake message is the ground truth.
+
+let parentWindow = null
+let initialPayload = null
+const listeners = new Set()
+
+export function initEmbedListener() {
+    window.addEventListener("message", ({ data, source }) => {
+        if (source === window) return
+        const wasEmbedded = !!parentWindow
+        parentWindow = source
+        if (!wasEmbedded) {
+            initialPayload = data
+            listeners.forEach(fn => fn(data))
+        }
+    })
+}
+
+export function isEmbedded() {
+    return !!parentWindow
+}
+
+export function getInitialPayload() {
+    return initialPayload
+}
+
+export function onEmbedChange(fn) {
+    listeners.add(fn)
+    return () => listeners.delete(fn)
+}
+
+export function postToParent(message) {
+    parentWindow?.postMessage(message, "*")
+}


### PR DESCRIPTION
## Summary
- #164

Adds the SeqImprove side of the SynBioSuite embed integration. SeqImprove now detects when it's running inside a SynBioSuite iframe and exposes a "Save to Working Directory" button that posts the current SBOL back to the host. It also consumes any SBOL the host sends in the handshake so existing files round-trip through the editor cleanly.

PR on the SynBioSuite side: MyersResearchGroup/SynBioSuite#345.

### How the embed detection works

`modules/embedded.js` registers a postMessage listener at module load. The first non-self message captures the parent window and flips `isEmbedded()` to true. We do this instead of checking `window.parent !== window` because that condition is also true when the page is opened in a new tab via `window.open`, which would falsely make us think we're embedded.

The `useIsEmbedded()` hook in `hooks/misc.jsx` subscribes to that transition so the Save button appears as soon as the handshake arrives, even if React already finished its first render.

`App.jsx` consumes any `{ sbol }` from the parent's handshake by calling `loadSBOL(data.sbol, FILE_TYPES.SBOL2)`, then posts `'graphServiceLoadedSBOL'` so the parent's loading overlay can clear.

`CurationForm.jsx` renders a split button when embedded: the primary button posts the SBOL, and the chevron exposes the existing Download SBOL2 / Upload to SynBioHub options as fallback paths. Standalone behavior is unchanged.