### PR TITLE
Guard parseTextAnnotations against undefined description

### DIFF
--- a/apps/web/src/modules/sbol.js
+++ b/apps/web/src/modules/sbol.js
@@ -297,6 +297,10 @@ export function getExistingSequenceAnnotations(componentDefinition) {
 
 
 export function parseTextAnnotations(description) {
+    if (!description) {
+        return { buffer: new TextBuffer(""), annotations: [] }
+    }
+
     // Use a buffer to replace annotations with their regular text
     const reverseBuffer = new TextBuffer(description)
 


### PR DESCRIPTION
Loading an SBOL file whose root component has no `richDescription` crashes with:

```
SBOL2 loading error: TypeError: Cannot read properties of undefined (reading 'matchAll')
    at parseTextAnnotations (sbol.js:303)
    at loadSBOL (store.js:56)
```

`parseTextAnnotations` was calling `description.matchAll(...)` directly on its argument. `loadSBOL` passes `document.root.richDescription`, which is undefined for any document where the root component doesn't have one.

Hit this trying to load `Combinatorial_Violacein_Pathways.xml`. Fix returns an empty buffer/annotations result when the description is missing so the rest of `loadSBOL` continues as if there were no text annotations to parse.