### PR TITLE
Passes component displayID back to SynbioSuite

### DIFF
--- a/apps/web/src/components/CurationForm.jsx
+++ b/apps/web/src/components/CurationForm.jsx
@@ -523,7 +523,7 @@ export default function CurationForm({ }) {
                 await handleEndNameEdit(false);
             }
             const sbol = useStore.getState().exportDocument(false);
-            postToParent({ sbol, source: "seqimprove" });
+            postToParent({ sbol, displayID: workingDisplayID, source: "seqimprove" });
             showNotificationSuccess("Saved to SynBioSuite", "Your SBOL was sent to the host app.");
         } catch (err) {
             const message = err?.message ?? String(err);


### PR DESCRIPTION
This PR modifies the post message sent to SynBioSuite to include the displayID as a separate piece of information.